### PR TITLE
Deprecate Block for_each in favor of join_map

### DIFF
--- a/examples/basic/main.rs
+++ b/examples/basic/main.rs
@@ -1,6 +1,6 @@
 extern crate jens;
 
-use jens::grammar::File;
+use jens::{block::Block, grammar::File};
 
 fn main() {
     let emoji: Vec<(&str, &str)> = vec![
@@ -18,19 +18,20 @@ fn main() {
             "map",
             f.template("map").set("name", "EMOJI_MAP").set(
                 "entries",
-                f.template("key_value")
-                    .for_each(&emoji, |&(key, val), block| {
-                        block.set("key", key).set("value", val)
-                    }),
+                Block::join_map(&emoji, |&(key, val), _| {
+                    f.template("key_value").set("key", key).set("value", val)
+                }),
             ),
-        ).set(
+        )
+        .set(
             "logger",
             f.template("logger").set(
                 "functions",
-                f.template("log_function")
-                    .for_each(&emoji, |&(key, _), block| {
-                        block.set("key", key).set("map", "EMOJI_MAP")
-                    }),
+                Block::join_map(&emoji, |&(key, _), _| {
+                    f.template("log_function")
+                        .set("key", key)
+                        .set("map", "EMOJI_MAP")
+                }),
             ),
         );
 

--- a/examples/json_validator/main.rs
+++ b/examples/json_validator/main.rs
@@ -97,8 +97,8 @@ fn main() {
 
     let output = f.template("main").set(
         "types",
-        f.template("type").for_each(types, |t, block| {
-            block
+        Block::join_map(types, |t, _| {
+            f.template("type")
                 .set("type_name", t.type_name.clone())
                 .set("type_def_fields", type_def_fields(&f, &t))
                 .set("serialize_fields", serialize_fields(&f, &t))
@@ -110,27 +110,25 @@ fn main() {
 }
 
 fn type_def_fields(f: &File, t: &TsType) -> Block {
-    f.template("type_def").for_each(&t.fields, |field, block| {
-        block
+    Block::join_map(&t.fields, |field, _| {
+        f.template("type_def")
             .set("field_name", field.field_name.clone())
             .set("field_type", field.field_type.get_ts_type())
     })
 }
 
 fn serialize_fields(f: &File, t: &TsType) -> Block {
-    f.template("serialize_field")
-        .for_each(&t.fields, |field, block| {
-            block
-                .set("field_name", field.field_name.clone())
-                .set("serialize_func", field.field_type.get_serialize_func())
-        })
+    Block::join_map(&t.fields, |field, _| {
+        f.template("serialize_field")
+            .set("field_name", field.field_name.clone())
+            .set("serialize_func", field.field_type.get_serialize_func())
+    })
 }
 
 fn deserialize_fields(f: &File, t: &TsType) -> Block {
-    f.template("deserialize_field")
-        .for_each(&t.fields, |field, block| {
-            block
-                .set("field_name", field.field_name.clone())
-                .set("deserialize_func", field.field_type.get_deserialize_func())
-        })
+    Block::join_map(&t.fields, |field, _| {
+        f.template("deserialize_field")
+            .set("field_name", field.field_name.clone())
+            .set("deserialize_func", field.field_type.get_deserialize_func())
+    })
 }

--- a/src/block.rs
+++ b/src/block.rs
@@ -142,8 +142,9 @@ impl Block {
     }
 
     /// Run a function that maps over each item in an iterator, then join the results.
-    /// Provides an `IteratorLocation` for checking whether the
-    /// current item is the first/last/only/nth item in the list.
+    ///
+    /// Provides an `IteratorLocation` for checking whether the current item is the
+    /// first/last/only/nth item in the list.
     pub fn join_map<T, U, F>(iter: T, mapper: F) -> Self
     where
         T: IntoIterator<Item = U>,
@@ -165,7 +166,10 @@ impl Block {
         }
     }
 
-    /// Repeat a template for each element of some iterable value
+    /// Repeat a template for each element of some iterable value.
+    ///
+    /// Deprecated in favor of `join_map`.
+    #[deprecated]
     pub fn for_each<T, U, F>(self, iter: T, mapper: F) -> Self
     where
         T: IntoIterator<Item = U>,


### PR DESCRIPTION
Deprecate the `Block::for_each` in favor of `Block::join_map`. Examples have been updated.