### PR TITLE
Reexport Grammar and Block structs

### DIFF
--- a/examples/basic/main.rs
+++ b/examples/basic/main.rs
@@ -1,6 +1,6 @@
 extern crate jens;
 
-use jens::{block::Block, grammar::File};
+use jens::{Block, File};
 
 fn main() {
     let emoji: Vec<(&str, &str)> = vec![

--- a/examples/json_validator/main.rs
+++ b/examples/json_validator/main.rs
@@ -1,7 +1,6 @@
 extern crate jens;
 
-use jens::block::Block;
-use jens::grammar::File;
+use jens::{Block, File};
 
 enum Json {
     JsString,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,5 +2,8 @@ extern crate pest;
 #[macro_use]
 extern crate pest_derive;
 
-pub mod block;
-pub mod grammar;
+pub use block::{Block, Line};
+pub use grammar::File;
+
+mod block;
+mod grammar;


### PR DESCRIPTION
Merging this PR will have minor breaking changes to clients as the import paths have changed. It is probably a good idea to bump the version to 0.4.0 on publish.