### PR TITLE
Add Tests for Template Parsers

### DIFF
--- a/src/block.rs
+++ b/src/block.rs
@@ -200,7 +200,7 @@ impl<'a> From<&'a Template> for Block {
 
         for template_line in &t.lines {
             let mut segments: Vec<LineSegment> =
-                Vec::with_capacity(template_line.content.len() + 1);
+                Vec::with_capacity(template_line.segments.len() + 1);
 
             // Add correct amount of whitespace at the beginning of the block
             let indentation_len = template_line.indentation.len();
@@ -209,7 +209,7 @@ impl<'a> From<&'a Template> for Block {
                 segments.push(LineSegment::Content(String::from(indentation)));
             }
 
-            for template_segment in &template_line.content {
+            for template_segment in &template_line.segments {
                 segments.push(match template_segment {
                     Segment::Placeholder(x) => LineSegment::Placeholder(x.clone()),
                     Segment::Content(x) => LineSegment::Content(x.clone()),

--- a/src/parser/segment.rs
+++ b/src/parser/segment.rs
@@ -1,4 +1,4 @@
-use crate::parser::Rule;
+use crate::parser::{get_ident, Rule};
 use pest::iterators::Pair;
 
 #[derive(Debug, PartialEq)]
@@ -18,10 +18,6 @@ impl From<Pair<'_, Rule>> for Segment {
     }
 }
 
-fn get_ident(pair: Pair<'_, Rule>) -> String {
-    pair.into_inner().nth(0).unwrap().as_str().into()
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -34,15 +30,15 @@ mod tests {
     #[test]
     fn placeholder() {
         let templates = parse(&tmpl_line("${x}")).unwrap();
-        let segments = &templates[0].lines[0].content;
+        let segments = &templates[0].lines[0].segments;
 
         assert_eq!(segments, &[Segment::Placeholder("x".into())]);
     }
 
     #[test]
-    fn content() {
+    fn raw_content() {
         let templates = parse(&tmpl_line("content")).unwrap();
-        let segments = &templates[0].lines[0].content;
+        let segments = &templates[0].lines[0].segments;
 
         assert_eq!(segments, &[Segment::Content("content".into())]);
     }
@@ -50,7 +46,7 @@ mod tests {
     #[test]
     fn escaped_dollar() {
         let templates = parse(&tmpl_line("\\$")).unwrap();
-        let segments = &templates[0].lines[0].content;
+        let segments = &templates[0].lines[0].segments;
 
         assert_eq!(segments, &[Segment::Content("$".into())]);
     }
@@ -58,7 +54,7 @@ mod tests {
     #[test]
     fn escaped_placeholder() {
         let templates = parse(&tmpl_line("\\${x}")).unwrap();
-        let segments = &templates[0].lines[0].content;
+        let segments = &templates[0].lines[0].segments;
 
         assert_eq!(
             segments,

--- a/src/parser/template.rs
+++ b/src/parser/template.rs
@@ -1,4 +1,4 @@
-use crate::parser::{parse_phase2, segment::Segment, Rule};
+use crate::parser::{get_ident, parse_phase2, segment::Segment, Rule};
 use pest::iterators::Pair;
 
 #[derive(Debug, Default, PartialEq)]
@@ -14,11 +14,11 @@ impl<'a> From<Pair<'a, Rule>> for Template {
 
         for item in pair.into_inner() {
             match item.as_rule() {
-                Rule::template_decl => {
-                    template.name = item.into_inner().next().unwrap().as_str().into()
-                }
+                Rule::template_decl => template.name = get_ident(item),
                 Rule::template_line => template.lines.push(item.into()),
-                Rule::template_terminator => template.indent_ignored = item.as_str().len() - 1,
+                Rule::template_terminator => {
+                    template.indent_ignored = item.as_str().matches("-").count()
+                }
                 Rule::template_empty_line => template.lines.push(TemplateLine::default()),
                 _ => unreachable!(),
             }
@@ -30,23 +30,160 @@ impl<'a> From<Pair<'a, Rule>> for Template {
 #[derive(Debug, Default, PartialEq)]
 pub(crate) struct TemplateLine {
     pub(crate) indentation: String,
-    pub(crate) content: Vec<Segment>,
+    pub(crate) segments: Vec<Segment>,
 }
 
 impl<'a> From<Pair<'a, Rule>> for TemplateLine {
     fn from(pair: Pair<'a, Rule>) -> TemplateLine {
         let mut indentation = String::new();
-        let mut content = vec![];
+        let mut segments = vec![];
         for item in pair.into_inner() {
             match item.as_rule() {
                 Rule::significant_whitespace => indentation = item.as_str().into(),
-                Rule::template_content => content = parse_phase2(item.as_str()).unwrap(),
+                Rule::template_content => segments = parse_phase2(item.as_str()).unwrap(),
                 _ => unreachable!(),
             }
         }
         TemplateLine {
             indentation,
-            content,
+            segments,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::parser::{parse, segment::Segment};
+
+    #[test]
+    fn empty_template() {
+        let templates = parse("main =\n----").unwrap();
+
+        assert_eq!(
+            templates,
+            &[Template {
+                name: "main".into(),
+                indent_ignored: 4,
+                lines: vec![]
+            }]
+        );
+    }
+
+    #[test]
+    fn space_indented_content() {
+        let templates = parse("main =\n    indent4\n     indent5\n----").unwrap();
+
+        assert_eq!(
+            templates,
+            &[Template {
+                name: "main".into(),
+                indent_ignored: 4,
+                lines: vec![
+                    TemplateLine {
+                        indentation: "    ".into(),
+                        segments: vec![Segment::Content("indent4".into())],
+                    },
+                    TemplateLine {
+                        indentation: "     ".into(),
+                        segments: vec![Segment::Content("indent5".into())],
+                    }
+                ]
+            }]
+        );
+    }
+
+    #[test]
+    fn tab_indented() {
+        let templates = parse("main =\n\tindent1\n\t\tindent2\n-").unwrap();
+
+        assert_eq!(
+            templates,
+            &[Template {
+                name: "main".into(),
+                indent_ignored: 1,
+                lines: vec![
+                    TemplateLine {
+                        indentation: "\t".into(),
+                        segments: vec![Segment::Content("indent1".into())],
+                    },
+                    TemplateLine {
+                        indentation: "\t\t".into(),
+                        segments: vec![Segment::Content("indent2".into())],
+                    }
+                ]
+            }]
+        );
+    }
+
+    #[test]
+    fn mixed_indentation() {
+        let templates = parse("main =\n    \tindent\n----").unwrap();
+
+        assert_eq!(
+            templates,
+            &[Template {
+                name: "main".into(),
+                indent_ignored: 4,
+                lines: vec![TemplateLine {
+                    indentation: "    \t".into(),
+                    segments: vec![Segment::Content("indent".into())],
+                }]
+            }]
+        );
+    }
+
+    #[test]
+    fn ignore_more_indentation() {
+        let templates = parse("main =\n  content\n----").unwrap();
+
+        assert_eq!(
+            templates,
+            &[Template {
+                name: "main".into(),
+                indent_ignored: 4,
+                lines: vec![TemplateLine {
+                    indentation: "  ".into(),
+                    segments: vec![Segment::Content("content".into())],
+                }]
+            }]
+        );
+    }
+
+    #[test]
+    fn ignore_inner_template() {
+        let templates = parse("main =\n    main =\n        x\n    ----\n----").unwrap();
+
+        assert_eq!(
+            templates,
+            &[Template {
+                name: "main".into(),
+                indent_ignored: 4,
+                lines: vec![
+                    TemplateLine {
+                        indentation: "    ".into(),
+                        segments: vec![Segment::Content("main =".into())],
+                    },
+                    TemplateLine {
+                        indentation: "        ".into(),
+                        segments: vec![Segment::Content("x".into())],
+                    },
+                    TemplateLine {
+                        indentation: "    ".into(),
+                        segments: vec![Segment::Content("----".into())],
+                    }
+                ]
+            }]
+        );
+    }
+
+    #[test]
+    fn invalid_start() {
+        assert!(parse("main\n  content\n--").is_err())
+    }
+
+    #[test]
+    fn invalid_end() {
+        assert!(parse("main =\n content\n").is_err())
     }
 }


### PR DESCRIPTION
Add tests for the template parsers.

I think something that would be good to work out/document is what the ending lines in the template represent specifically when it comes to ignoring indentation.

```
main =
    some content
----      // <-- these lines
```

It seems to be that the dashes indicate how many *characters* to ignore which I think is the most flexible approach. 

That way, we also don't have to worry if the number of dashes is more than the actual whitespace as it'll be up to the user (person who writes the templates) to ensure it all lines up. 

This does mean though that the template will be required to have at least one character of ignored indentation, which I don't think is unreasonable.